### PR TITLE
Fix missing traceback import

### DIFF
--- a/pdf_extractor.py
+++ b/pdf_extractor.py
@@ -15,6 +15,7 @@ import pytesseract
 from PIL import Image
 import tempfile
 import re
+import traceback
 
 # Configure logging to output to stdout/stderr
 logging.basicConfig(


### PR DESCRIPTION
## Summary
- add missing `traceback` import in `pdf_extractor.py`

## Testing
- `python -m py_compile app.py pdf_extractor.py`

------
https://chatgpt.com/codex/tasks/task_e_685b2434afac832d948a1fa8d64bb399