### PR TITLE
Improve logging and file handling security

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,27 +1,24 @@
 import os
 import logging
 import sys
+import io
 from flask import Flask, request, render_template, send_file, jsonify
 from werkzeug.utils import secure_filename
 from pdf_extractor import extract_text_from_pdf
 import tempfile
 import traceback
 
-# Configure logging to output to stdout/stderr
+# Configure logging to output to stdout
 logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.StreamHandler(sys.stdout),
-        logging.StreamHandler(sys.stderr)
-    ]
+    handlers=[logging.StreamHandler(sys.stdout)]
 )
 logger = logging.getLogger(__name__)
 
 # Also configure werkzeug logger
 werkzeug_logger = logging.getLogger('werkzeug')
 werkzeug_logger.setLevel(logging.INFO)
-werkzeug_logger.addHandler(logging.StreamHandler(sys.stdout))
 
 app = Flask(__name__)
 app.config['MAX_CONTENT_LENGTH'] = 16 * 1024 * 1024  # 16MB max file size
@@ -29,32 +26,37 @@ app.config['UPLOAD_FOLDER'] = tempfile.gettempdir()
 
 # Configure Flask logging
 app.logger.setLevel(logging.INFO)
-app.logger.addHandler(logging.StreamHandler(sys.stdout))
 
 ALLOWED_EXTENSIONS = {'pdf'}
 
+
 def allowed_file(filename):
-    return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
+    return '.' in filename and filename.rsplit(
+        '.', 1)[1].lower() in ALLOWED_EXTENSIONS
+
 
 @app.before_request
 def log_request_info():
-    app.logger.info('Headers: %s', request.headers)
-    app.logger.info('Body: %s', request.get_data())
+    app.logger.info('%s %s', request.method, request.path)
+
 
 @app.after_request
 def log_response_info(response):
-    app.logger.info('Response: %s', response.get_data())
+    app.logger.info('Status: %s', response.status)
     return response
+
 
 @app.route('/')
 def index():
     app.logger.info('Serving index page')
     return render_template('index.html')
 
+
 @app.route('/features')
 def features():
     app.logger.info('Serving features page')
     return render_template('features.html')
+
 
 @app.route('/upload', methods=['POST'])
 def upload_file():
@@ -63,20 +65,24 @@ def upload_file():
         if 'file' not in request.files:
             app.logger.error('No file part in request')
             return jsonify({'error': 'No file part'}), 400
-        
+
         file = request.files['file']
         if file.filename == '':
             app.logger.error('No selected file')
             return jsonify({'error': 'No selected file'}), 400
-        
+
         if not allowed_file(file.filename):
             app.logger.error('Invalid file type: %s', file.filename)
+            return jsonify({'error': 'Invalid file type'}), 400
+
+        if file.mimetype != 'application/pdf':
+            app.logger.error('Invalid MIME type: %s', file.mimetype)
             return jsonify({'error': 'Invalid file type'}), 400
 
         # Create temp directory if it doesn't exist
         temp_dir = os.path.join(app.config['UPLOAD_FOLDER'], 'darkhole_temp')
         os.makedirs(temp_dir, exist_ok=True)
-        
+
         # Save uploaded file
         filename = secure_filename(file.filename)
         filepath = os.path.join(temp_dir, filename)
@@ -87,13 +93,15 @@ def upload_file():
         try:
             text = extract_text_from_pdf(filepath)
             app.logger.info('Text extraction successful')
-            
+
             # Save extracted text
             output_path = os.path.join(temp_dir, 'extracted_text.txt')
+            if os.path.exists(output_path):
+                os.remove(output_path)
             with open(output_path, 'w', encoding='utf-8') as f:
                 f.write(text)
             app.logger.info('Extracted text saved to: %s', output_path)
-            
+
             return jsonify({
                 'message': 'File processed successfully',
                 'download_url': '/download'
@@ -108,21 +116,29 @@ def upload_file():
                 os.remove(filepath)
                 app.logger.info('Uploaded file cleaned up: %s', filepath)
             except Exception as e:
-                app.logger.error('Failed to clean up uploaded file: %s', str(e))
+                app.logger.error(
+                    'Failed to clean up uploaded file: %s', str(e))
     except Exception as e:
         app.logger.error('Upload processing failed: %s', str(e))
         app.logger.error('Traceback: %s', traceback.format_exc())
         return jsonify({'error': 'Upload processing failed'}), 500
 
+
 @app.route('/download')
 def download_file():
     try:
         app.logger.info('Download request received')
-        output_path = os.path.join(app.config['UPLOAD_FOLDER'], 'darkhole_temp', 'extracted_text.txt')
+        output_path = os.path.join(
+            app.config['UPLOAD_FOLDER'],
+            'darkhole_temp',
+            'extracted_text.txt')
         if os.path.exists(output_path):
             app.logger.info('Sending file: %s', output_path)
+            with open(output_path, 'rb') as f:
+                data = f.read()
+            os.remove(output_path)
             return send_file(
-                output_path,
+                io.BytesIO(data),
                 as_attachment=True,
                 download_name='extracted_text.txt',
                 mimetype='text/plain'
@@ -134,15 +150,19 @@ def download_file():
         app.logger.error('Traceback: %s', traceback.format_exc())
         return jsonify({'error': 'Download failed'}), 500
 
+
 @app.errorhandler(404)
 def handle_404(e):
     app.logger.error('404 error: %s', request.url)
     return jsonify({'error': 'Not Found'}), 404
 
+
 @app.errorhandler(413)
 def handle_413(e):
     app.logger.error('413 error: File too large')
-    return jsonify({'error': 'File too large. Please upload a smaller PDF.'}), 413
+    return jsonify(
+        {'error': 'File too large. Please upload a smaller PDF.'}), 413
+
 
 @app.errorhandler(500)
 def handle_500(e):
@@ -150,5 +170,6 @@ def handle_500(e):
     app.logger.error('Traceback: %s', traceback.format_exc())
     return jsonify({'error': 'Internal server error'}), 500
 
+
 if __name__ == '__main__':
-    app.run(debug=True) 
+    app.run()

--- a/pdf_extractor.py
+++ b/pdf_extractor.py
@@ -12,20 +12,18 @@ import io
 import fitz  # PyMuPDF
 from pdf2image import convert_from_path
 import pytesseract
-from PIL import Image
 import tempfile
 import re
+import traceback
 
-# Configure logging to output to stdout/stderr
+# Configure logging to output to stdout
 logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.StreamHandler(sys.stdout),
-        logging.StreamHandler(sys.stderr)
-    ]
+    handlers=[logging.StreamHandler(sys.stdout)],
 )
 logger = logging.getLogger(__name__)
+
 
 def extract_text_from_pdf(pdf_path):
     """Extract text from PDF using multiple methods."""
@@ -33,13 +31,14 @@ def extract_text_from_pdf(pdf_path):
     extractor = PDFExtractor(pdf_path)
     return extractor.extract()
 
+
 class PDFExtractor:
     def __init__(self, pdf_path, dpi=150, min_text_length=50):
         self.pdf_path = pdf_path
         self.dpi = dpi
         self.min_text_length = min_text_length
         self.output = []
-        
+
     def clean_text(self, text):
         """Clean and normalize extracted text."""
         # Remove excessive whitespace
@@ -50,7 +49,7 @@ class PDFExtractor:
         text = text.replace('|', 'I')
         text = text.replace('l', 'I')
         return text.strip()
-    
+
     def extract_with_pdfminer(self):
         """Extract text using PDFMiner."""
         try:
@@ -62,13 +61,14 @@ class PDFExtractor:
                 if not document.is_extractable:
                     logger.warning("PDF is not extractable with PDFMiner")
                     return []
-                
+
                 rsrcmgr = PDFResourceManager()
                 laparams = LAParams()
-                
+
                 for page in PDFPage.create_pages(document):
                     output_string = io.StringIO()
-                    device = TextConverter(rsrcmgr, output_string, laparams=laparams)
+                    device = TextConverter(
+                        rsrcmgr, output_string, laparams=laparams)
                     interpreter = PDFPageInterpreter(rsrcmgr, device)
                     interpreter.process_page(page)
                     text = output_string.getvalue()
@@ -76,31 +76,31 @@ class PDFExtractor:
                         text_pages.append(text.strip())
                     device.close()
                     output_string.close()
-            
+
             logger.info(f"PDFMiner extracted {len(text_pages)} pages")
             return text_pages
         except Exception as e:
             logger.error(f"PDFMiner extraction failed: {str(e)}")
             logger.error(f"Traceback: {traceback.format_exc()}")
             return []
-    
+
     def extract_with_pymupdf(self):
         """Extract text using PyMuPDF."""
         try:
             logger.info("Extracting text with PyMuPDF...")
             text_pages = []
-            doc = fitz.open(self.pdf_path)
-            for page in doc:
-                text = page.get_text()
-                if text.strip():
-                    text_pages.append(text.strip())
+            with fitz.open(self.pdf_path) as doc:
+                for page in doc:
+                    text = page.get_text()
+                    if text.strip():
+                        text_pages.append(text.strip())
             logger.info(f"PyMuPDF extracted {len(text_pages)} pages")
             return text_pages
         except Exception as e:
             logger.error(f"PyMuPDF extraction failed: {str(e)}")
             logger.error(f"Traceback: {traceback.format_exc()}")
             return []
-    
+
     def extract_with_ocr(self):
         """Extract text using OCR."""
         try:
@@ -112,13 +112,15 @@ class PDFExtractor:
                 thread_count=1,
                 fmt='jpeg'
             )
-            
+
             for i, image in enumerate(images):
-                logger.info(f"Processing page {i+1} with OCR")
+                logger.info(f"Processing page {i + 1} with OCR")
                 # Convert to grayscale
                 image = image.convert('L')
                 # Save to temporary file
-                with tempfile.NamedTemporaryFile(suffix='.jpg', delete=False) as temp_file:
+                with tempfile.NamedTemporaryFile(
+                    suffix='.jpg', delete=False
+                ) as temp_file:
                     image.save(temp_file.name, 'JPEG')
                     # Perform OCR
                     text = pytesseract.image_to_string(temp_file.name)
@@ -126,87 +128,98 @@ class PDFExtractor:
                         text_pages.append(text.strip())
                     # Clean up
                     os.unlink(temp_file.name)
-            
+
             logger.info(f"OCR extracted {len(text_pages)} pages")
             return text_pages
         except Exception as e:
             logger.error(f"OCR extraction failed: {str(e)}")
             logger.error(f"Traceback: {traceback.format_exc()}")
             return []
-    
+
     def merge_texts(self, pdfminer_texts, pymupdf_texts, ocr_texts):
-        """Merge texts from different methods, preferring the longest valid text for each page."""
+        """Merge texts from different methods; keep longest per page."""
         merged_texts = []
-        for i in range(max(len(pdfminer_texts), len(pymupdf_texts), len(ocr_texts))):
+        for i in range(max(len(pdfminer_texts), len(
+                pymupdf_texts), len(ocr_texts))):
             texts = []
-            if i < len(pdfminer_texts) and len(pdfminer_texts[i]) > self.min_text_length:
+            if i < len(pdfminer_texts) and len(
+                    pdfminer_texts[i]) > self.min_text_length:
                 texts.append(pdfminer_texts[i])
-            if i < len(pymupdf_texts) and len(pymupdf_texts[i]) > self.min_text_length:
+            if i < len(pymupdf_texts) and len(
+                    pymupdf_texts[i]) > self.min_text_length:
                 texts.append(pymupdf_texts[i])
             if i < len(ocr_texts) and len(ocr_texts[i]) > self.min_text_length:
                 texts.append(ocr_texts[i])
-            
+
             # Use the longest text for this page
             if texts:
                 merged_texts.append(max(texts, key=len))
             else:
                 merged_texts.append("")
-        
+
         return merged_texts
-    
+
     def extract(self):
         """Extract text using all available methods and combine results."""
         try:
             # Set a timeout for the entire extraction process
             start_time = time.time()
             timeout = 30  # 30 seconds timeout
-            
+
             # Try PDFMiner first (fastest)
             pdfminer_texts = self.extract_with_pdfminer()
             pdfminer_text = "\n".join(pdfminer_texts) if pdfminer_texts else ""
             if pdfminer_text and len(pdfminer_text.strip()) > 100:
                 logger.info("Using PDFMiner results")
                 return pdfminer_text
-                
+
             # Try PyMuPDF next
             pymupdf_texts = self.extract_with_pymupdf()
             pymupdf_text = "\n".join(pymupdf_texts) if pymupdf_texts else ""
             if pymupdf_text and len(pymupdf_text.strip()) > 100:
                 logger.info("Using PyMuPDF results")
                 return pymupdf_text
-                
+
             # Only try OCR if other methods failed and we haven't timed out
             if time.time() - start_time < timeout:
                 ocr_texts = self.extract_with_ocr()
                 if ocr_texts:
                     logger.info("Using OCR results")
                     return "\n".join(ocr_texts)
-            
+
             # If all methods failed or timed out, return the best result
             logger.warning("All extraction methods failed or timed out")
-            return pdfminer_text or pymupdf_text or "Text extraction failed. Please try a different PDF."
-            
+            return (
+                pdfminer_text
+                or pymupdf_text
+                or "Text extraction failed. Please try a different PDF."
+            )
+
         except Exception as e:
             logger.error(f"Text extraction failed: {str(e)}")
             logger.error(f"Traceback: {traceback.format_exc()}")
-            return "An error occurred during text extraction. Please try again."
+            return (
+                "An error occurred during text extraction. Please try again."
+            )
+
 
 def main():
     pdf_path = "responsiveRecord.pdf"
     output_path = "extracted_text.txt"
-    
+
     try:
         extractor = PDFExtractor(pdf_path)
         extracted_text = extractor.extract()
-        
+
         # Save to file
         with open(output_path, 'w', encoding='utf-8') as f:
             f.write(extracted_text)
-        
+
         logger.info(f"Extraction complete. Results saved to {output_path}")
-        
+
     except Exception as e:
         logger.error(f"Failed to process PDF: {str(e)}")
 
+
 if __name__ == "__main__":
-    main() 
+    main()


### PR DESCRIPTION
## Summary
- avoid logging full request and response bodies
- enforce PDF MIME type checking
- remove leftover extracted text files after download
- limit extractor logging to stdout and close PyMuPDF documents
- format code to satisfy flake8

## Testing
- `python -m py_compile app.py pdf_extractor.py`
- `flake8 app.py pdf_extractor.py`


------
https://chatgpt.com/codex/tasks/task_e_685b2434afac832d948a1fa8d64bb399